### PR TITLE
Flatten pdfs and parameter type pdf_path

### DIFF
--- a/extract_text.py
+++ b/extract_text.py
@@ -13,6 +13,7 @@ def main():
     parser.add_argument("--sort", action="store_true", help="Attempt to sort the text by reading order", default=False)
     parser.add_argument("--keep_hyphens", action="store_true", help="Keep hyphens in words", default=False)
     parser.add_argument("--pages", type=str, help="Comma separated pages to extract, like 1,2,3", default=None)
+    parser.add_argument("--flatten_pdf", action="store_true", help="Flatten form fields and annotations into page contents", default=False)
     parser.add_argument("--keep_chars", action="store_true", help="Keep character level information", default=False)
     parser.add_argument("--workers", type=int, help="Number of workers to use for parallel processing", default=None)
     args = parser.parse_args()
@@ -24,10 +25,10 @@ def main():
         assert all(p <= len(pdf_doc) for p in pages), "Invalid page number(s) provided"
 
     if args.json:
-        text = dictionary_output(args.pdf_path, sort=args.sort, page_range=pages, keep_chars=args.keep_chars, workers=args.workers)
+        text = dictionary_output(args.pdf_path, sort=args.sort, page_range=pages, flatten_pdf=args.flatten_pdf, keep_chars=args.keep_chars, workers=args.workers)
         text = json.dumps(text)
     else:
-        text = plain_text_output(args.pdf_path, sort=args.sort, hyphens=args.keep_hyphens, page_range=pages, workers=args.workers)
+        text = plain_text_output(args.pdf_path, sort=args.sort, hyphens=args.keep_hyphens, page_range=pages, flatten_pdf=args.flatten_pdf, workers=args.workers)
 
     if args.out_path is None:
         print(text)

--- a/pdftext/extraction.py
+++ b/pdftext/extraction.py
@@ -12,12 +12,14 @@ from pdftext.postprocessing import merge_text, sort_blocks, postprocess_text, ha
 from pdftext.settings import settings
 
 
-def process_pdf(pdf):
+def _process_pdf(pdf):
     if isinstance(pdf, str):
         pdf = pdfium.PdfDocument(pdf)
     else:
         if not isinstance(pdf, pdfium.PdfDocument):
             raise TypeError("pdf must be a file path string or a PdfDocument object")
+        
+    pdf.init_forms()
         
     return pdf
 
@@ -57,7 +59,7 @@ def _get_pages(pdf_doc, model=None, page_range=None, workers=None):
 
 
 def plain_text_output(pdf: str | pdfium.PdfDocument, sort=False, model=None, hyphens=False, page_range=None, workers=None) -> str:
-    pdf_doc = process_pdf(pdf)
+    pdf_doc = _process_pdf(pdf)
     text = paginated_plain_text_output(pdf_doc, sort=sort, model=model, hyphens=hyphens, page_range=page_range, workers=workers)
     return "\n".join(text)
 
@@ -81,7 +83,7 @@ def _process_span(span, page_width, page_height, keep_chars):
 
 
 def dictionary_output(pdf: str | pdfium.PdfDocument, sort=False, model=None, page_range=None, keep_chars=False, workers=None):
-    pdf_doc = process_pdf(pdf)
+    pdf_doc = _process_pdf(pdf)
     pages = _get_pages(pdf_doc, model, page_range, workers=workers)
     for page in pages:
         page_width, page_height = page["width"], page["height"]

--- a/pdftext/extraction.py
+++ b/pdftext/extraction.py
@@ -18,9 +18,10 @@ def _process_pdf(pdf):
     else:
         if not isinstance(pdf, pdfium.PdfDocument):
             raise TypeError("pdf must be a file path string or a PdfDocument object")
-        
+
+    # Must be called on the parent pdf, before the page was retrieved 
     pdf.init_forms()
-        
+    
     return pdf
 
 

--- a/pdftext/pdf/chars.py
+++ b/pdftext/pdf/chars.py
@@ -24,6 +24,11 @@ def get_pdfium_chars(pdf, page_range, fontname_sample_freq=settings.FONTNAME_SAM
 
     for page_idx in page_range:
         page = pdf.get_page(page_idx)
+        # Flatten form fields and annotations into page contents.
+        page._flatten(flag=pdfium_c.FLAT_NORMALDISPLAY)
+        # Flattening invalidates existing handles to the page.
+        # It is necessary to re-initialize the page handle after flattening.
+        page = pdf.get_page(page_idx)
         text_page = page.get_textpage()
         mediabox = page.get_mediabox()
         page_rotation = page.get_rotation()

--- a/pdftext/pdf/chars.py
+++ b/pdftext/pdf/chars.py
@@ -19,16 +19,20 @@ def update_previous_fonts(char_infos: List, i: int, prev_fontname: str, prev_fon
         char_infos[j]["font"]["flags"] = fontflags
 
 
-def get_pdfium_chars(pdf, page_range, fontname_sample_freq=settings.FONTNAME_SAMPLE_FREQ):
+def get_pdfium_chars(pdf, page_range, flatten_pdf, fontname_sample_freq=settings.FONTNAME_SAMPLE_FREQ):
     blocks = []
 
     for page_idx in page_range:
         page = pdf.get_page(page_idx)
-        # Flatten form fields and annotations into page contents.
-        page._flatten(flag=pdfium_c.FLAT_NORMALDISPLAY)
-        # Flattening invalidates existing handles to the page.
-        # It is necessary to re-initialize the page handle after flattening.
-        page = pdf.get_page(page_idx)
+
+        if flatten_pdf:
+            # Flatten form fields and annotations into page contents.
+            page._flatten(flag=pdfium_c.FLAT_NORMALDISPLAY)
+
+            # Flattening invalidates existing handles to the page.
+            # It is necessary to re-initialize the page handle after flattening.
+            page = pdf.get_page(page_idx)
+        
         text_page = page.get_textpage()
         mediabox = page.get_mediabox()
         page_rotation = page.get_rotation()


### PR DESCRIPTION
- The pdf_path argument is modified to accept string or PdfDocument object.
- Flatten form fields and annotations into page contents.
- flatten_pdf parameter is added.