### PR TITLE
deps: Add numpy v2.2.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1483,6 +1483,7 @@ python-versions = ">=3.9"
 files = [
     {file = "pymupdf-1.25.3-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:96878e1b748f9c2011aecb2028c5f96b5a347a9a91169130ad0133053d97915e"},
     {file = "pymupdf-1.25.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6ef753005b72ebfd23470f72f7e30f61e21b0b5e748045ec5b8f89e6e3068d62"},
+    {file = "pymupdf-1.25.3-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cbff443d899f37b17f1e67563cc03673d50b4bf33ccc237e73d34f18f3a07ccf"},
     {file = "pymupdf-1.25.3-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:46d90c4f9e62d1856e8db4b9f04a202ff4a7f086a816af73abdc86adb7f5e25a"},
     {file = "pymupdf-1.25.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5de51efdbe4d486b6c1111c84e8a231cbfb426f3d6ff31ab530ad70e6f39756"},
     {file = "pymupdf-1.25.3-cp39-abi3-win32.whl", hash = "sha256:bca72e6089f985d800596e22973f79cc08af6cbff1d93e5bda9248326a03857c"},
@@ -2113,4 +2114,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "ddd1896418384a59ea5cc93165805531aaa09c17748180768da7266c57c8307e"
+content-hash = "7643c082e5834030abdbd5ad67f960217b6db85f3c332bf237f4e072beaa72d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pydantic = "^2.7.1"
 pydantic-settings = "^2.2.1"
 
 click = "^8.1.8"
+numpy = "2.2.3"
 [tool.poetry.group.dev.dependencies]
 pymupdf = "^1.24.2"
 datasets = "^2.19.0"


### PR DESCRIPTION
Numpy is required for links (`pdf/utils.py`) but isn't explicitly stated as a dependency, breaking e.g. usage with `uvx` or `pipx`.