### PR TITLE
Convert correctly PDFium UTF-8 integers to char/string

### DIFF
--- a/pdftext/pdf/chars.py
+++ b/pdftext/pdf/chars.py
@@ -7,6 +7,9 @@ from pdftext.pdf.utils import get_fontname
 from pdftext.schema import Bbox, Char, Chars, Spans, Span
 
 
+MAX_UNICODE_INT = 1114111  # 0x10ffff
+
+
 def get_chars(textpage: pdfium.PdfTextPage, page_bbox: list[float], page_rotation: int, quote_loosebox=True) -> Chars:
     chars: Chars = []
 
@@ -15,7 +18,7 @@ def get_chars(textpage: pdfium.PdfTextPage, page_bbox: list[float], page_rotatio
     page_height = math.ceil(abs(y_end - y_start))
 
     for i in range(textpage.count_chars()):
-        text = chr(pdfium_c.FPDFText_GetUnicode(textpage, i))
+        text = utf8_int_to_string(pdfium_c.FPDFText_GetUnicode(textpage, i))
 
         rotation = pdfium_c.FPDFText_GetCharAngle(textpage, i)
         loosebox = (rotation == 0) and (text != "'" or quote_loosebox)
@@ -117,3 +120,35 @@ def deduplicate_chars(chars: Chars) -> Chars:
             deduped.append(word)
 
     return [char for word in deduped for char in word['chars']]
+
+
+def utf8_int_to_string(utf8_int: int) -> str:
+    """Decode UTF-8 integer to string.
+`
+    PDFium's `FPDFText_GetUnicode` returns unsigned 32-bit integer. Integers ≤ 1114111 are valid
+    Unicode codepoint and can be converted with python in-built `chr` function.
+    Larger integers are UTF-8 bytes packed into integers and must be handled separately.
+
+    Parameters
+    ----------
+    utf8_int
+        Unsgined 32-bit ingeger value from FPDFText_GetUnicode that may be either a valid Unicode
+        codepoint, or UTF-8 bytes packed as an integer.
+
+    Returns
+    -------
+    The decoded character or string.
+
+    Examples
+    --------
+    >>> utf8_int_to_string(65)  # Valid Unicode
+    'A'
+    >>> utf8_int_to_string(15112101)  # UTF-8 bytes for '日'
+    '日'
+    """
+    if utf8_int <= MAX_UNICODE_INT:
+        return chr(utf8_int)
+    # Compute byte length using 8-bit ceiling
+    byte_length = (utf8_int.bit_length() + 7) // 8
+    bytes_obj = utf8_int.to_bytes(byte_length, "big")
+    return bytes_obj.decode("utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,10 @@ def pdf_path():
 def pdf_path2():
     return "tests/data/communication.pdf"
 
+@pytest.fixture(scope="session")
+def pdf_with_non_unicode_chars():
+    return "tests/data/non_unicode_chars.pdf"
+
 @pytest.fixture()
 def pdf_doc(pdf_path):
     doc = pdfium.PdfDocument(pdf_path)

--- a/tests/data/non_unicode_chars.pdf
+++ b/tests/data/non_unicode_chars.pdf
@@ -1,0 +1,95 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /HeiseiKakuGo-W5 /DescendantFonts [ <<
+/BaseFont /HeiseiKakuGo-W5 /CIDSystemInfo <<
+/Ordering (Japan1) /Registry (Adobe) /Supplement 2
+>> /DW 1000 /FontDescriptor <<
+/Ascent 752 /CapHeight 737 /Descent -221 /Flags 4 /FontBBox [ -92 -250 1010 922 ] /FontName /HeiseKakuGo-W5 
+  /ItalicAngle 0 /StemH 0 /StemV 114 /Type /FontDescriptor /XHeight 553
+>> /Subtype /CIDFontType0 /Type /Font 
+  /W [ 1 [ 277 305 500 668 668 906 727 305 445 445 
+  508 668 305 379 305 539 ] 17 26 668 27 [ 305 305 668 668 668 566 871 727 637 652 
+  699 574 555 676 687 242 492 664 582 789 
+  707 734 582 734 605 605 641 668 727 945 
+  609 609 574 445 668 445 668 668 590 555 
+  609 547 602 574 391 609 582 234 277 539 
+  234 895 582 605 602 602 387 508 441 582 
+  562 781 531 570 555 449 246 449 668 ] 231 632 500 ]
+>> ] /Encoding /UniJIS-UCS2-H /Name /F2 /Subtype /Type0 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /ZapfDingbats /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20251007110345+02'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20251007110345+02'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 354
+>>
+stream
+Gasajb>,r/&A7`fk*R8`]M:fB8oW]cT&SggM_?DsBg>6diX5I-@M=GBC*dD)[,.A,S[Ad*4le:KJ.$p98K\MJ#"9mO`$;G(`9$gO4EW631!F)2;=(!&>)#oP,f>^8ee0QR$`oCu$\8KH$UGlZHC=D[P!AYrkcTbrKnZH1l2)$1&4c\2f"JE5&+%9k?CoN'5usi:6C.nK\_5nIIAg%&)OW?!ksj2Q27dZJ]krt"YIN,.U[n``^:gMCcZ,Gh]Xs@+fYh/;q]3-Yb@uQpn$]JRdjh]kN4#mmlJ5>#=I"/9f-o/#ic*f(V#-a&Ych+hanQ`9S:P,n:5k4\;?!bXk&\O0^>fE]+$*5a-3~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000001121 00000 n 
+0000001204 00000 n 
+0000001397 00000 n 
+0000001465 00000 n 
+0000001761 00000 n 
+0000001820 00000 n 
+trailer
+<<
+/ID 
+[<fb5aa7a7ea145957693c89b96233fd29><fb5aa7a7ea145957693c89b96233fd29>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 10
+>>
+startxref
+2264
+%%EOF

--- a/tests/pdf/test_chars.py
+++ b/tests/pdf/test_chars.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pdftext.pdf.chars import utf8_int_to_string
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "utf8_int, expected_str",
+    [
+        (65, "A"),  # uppercase letter
+        (97, "a"),  # lowercase letter
+        (51, "3"),  # number
+        (64, "@"),  # special character
+        # 3-byte UTF-8
+        (15112101, "日"),  # japanese char for day
+        (14989485, "中"),  # chinese char for middle
+        (15111815, "文"),  # chinese char for text/writing
+        (15113388, "本"),  # chinese char for book/origin
+        (15570332, "한"),  # korean hangul syllable
+        (14990232, "付"),  # japanese char for "attach/give" (part of date 日付)
+        # 4-byte UTF-8
+        (4036991104, "😀"),  # 😀
+        (4036991616, "🚀"),  # 🚀
+        (4036859279, "𝕏"),  # 𝕏, mathmetical notation
+        (4037057678, "𠜎"),  # 𠜎, CJK ideograph
+    ],
+)
+def test_utf8_int_to_string(utf8_int: int, expected_str: str) -> None:
+    assert utf8_int_to_string(utf8_int) == expected_str

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -42,3 +42,10 @@ def test_line_joining(pdf_path2):
     text = plain_text_output(pdf_path2, page_range=pages).lower()
     assert "the axis media control viewer toolbar" in text
     assert "axismediacontrolviewertoolbar" not in text
+
+
+def test_parsing_non_unicode_chars(pdf_with_non_unicode_chars):
+    text = plain_text_output(pdf_with_non_unicode_chars).lower()
+    assert "日" in text
+    assert "付" in text
+


### PR DESCRIPTION
Fixes #49.

Tests:
```
> pytest tests                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   

tests/pdf/test_chars.py ..............                                                                                                                                                                                                                                                                                                                [ 60%]
tests/test_extraction.py .......                                                                                                                                                                                                                                                                                                                      [ 91%]
tests/test_tables.py ..   
````