### PR TITLE
Allow bbox overlap on superscript span-break condition

### DIFF
--- a/pdftext/pdf/pages.py
+++ b/pdftext/pdf/pages.py
@@ -116,7 +116,7 @@ def get_spans(chars: Chars, superscript_height_threshold: float = 0.8, line_dist
         if all([
             char["bbox"][1] < (span["bbox"][1] - span["bbox"].height * line_distance_threshold), # char top is above span
             char["bbox"][3] < (span["bbox"].height * superscript_height_threshold) + span["bbox"][1], # char bottom is not full line height
-            char["bbox"][0] > span["bbox"][2], # char is to the right of the span
+            char["bbox"][2] > span["bbox"][2], # char is to the right of the span
         ]):
             span_break()
             continue


### PR DESCRIPTION
fix: allow overlap between bounding boxes when checking if char is to the right of the span. This change uses the chars right edge for the condition, instead of the left edge. This allows overlap, without adding a threshold number. Improves superscript detection when char bbox overlaps slightly with previous span.

Tested with: https://doi.org/10.1177/1748006X17699145 Fixes #53