### PR TITLE
fix(links): attach a link to every span its rect covers (#42)

### DIFF
--- a/pdftext/pdf/links.py
+++ b/pdftext/pdf/links.py
@@ -8,6 +8,10 @@ import pypdfium2.raw as pdfium_c
 from pdftext.pdf.utils import matrix_intersection_area
 from pdftext.schema import Bbox, Link, Page, PageReference, Pages, Span
 
+# Fraction of the smaller of (span area, link area) that has to be covered before a
+# link is attached to a span it is not the best match for.
+LINK_SPAN_COVERAGE_THRESHOLD = 0.5
+
 
 def _get_dest_position(dest) -> Optional[Tuple[float, float]]:
     has_x = ctypes.c_int()
@@ -136,6 +140,29 @@ def _get_annot_link(annot, page_idx: int, pdf: pdfium.PdfDocument, page_bbox: Li
     return link
 
 
+def _bbox_area(bbox: List[float]) -> float:
+    return max(0.0, bbox[2] - bbox[0]) * max(0.0, bbox[3] - bbox[1])
+
+
+def _linked_span_indices(intersection_link, span_bboxes: List[List[float]], link_bbox: List[float], max_intersection: int) -> List[int]:
+    """
+    Returns every span index the link should be attached to: the largest overlap
+    plus any other span the link substantially covers. Normalizing by the smaller
+    of the two areas keeps both a short span fully inside the link and a long span
+    that swallows the whole link, while ignoring the sliver of the neighbouring
+    line a link rect often reaches into.
+    """
+    indices = [max_intersection]
+    link_area = _bbox_area(link_bbox)
+    for span_idx, area in enumerate(intersection_link):
+        if span_idx == max_intersection or area <= 0:
+            continue
+        denom = min(_bbox_area(span_bboxes[span_idx]), link_area)
+        if denom > 0 and area / denom >= LINK_SPAN_COVERAGE_THRESHOLD:
+            indices.append(span_idx)
+    return indices
+
+
 def merge_links(page: Page, pdf: pdfium.PdfDocument, refs: PageReference):
     """
     Merges links with spans. Some spans can also have multiple links associated with them.
@@ -157,8 +184,7 @@ def merge_links(page: Page, pdf: pdfium.PdfDocument, refs: PageReference):
         if intersection_link.sum() == 0:
             continue
 
-        max_intersection = intersection_link.argmax()
-        span = spans[max_intersection]
+        max_intersection = int(intersection_link.argmax())
 
         dest_page = link['dest_page']
         if dest_page is not None:
@@ -174,8 +200,16 @@ def merge_links(page: Page, pdf: pdfium.PdfDocument, refs: PageReference):
             ref = refs.add_ref(dest_page, dest_pos)
             link['url'] = ref.url
 
-        span_link_map.setdefault(max_intersection, [])
-        span_link_map[max_intersection].append(link)
+        # A single link annotation routinely covers more than one span, because a
+        # linked phrase gets split whenever the font changes (bold words, the
+        # zero-width spacers pdfium emits between words, ...). Keying only on the
+        # largest overlap leaves every other part of the anchor without a url, so
+        # also take the spans the link substantially covers. `_reconstruct_spans`
+        # still decides char by char, so a partially covered span is split rather
+        # than tagged wholesale.
+        for span_idx in _linked_span_indices(intersection_link, span_bboxes, link['bbox'], max_intersection):
+            span_link_map.setdefault(span_idx, [])
+            span_link_map[span_idx].append(link)
 
     span_idx = 0
     for block in page["blocks"]:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -210,3 +210,40 @@ def test_perpendicular_text_separate_lines(tmp_path):
             texts = {span["text"].strip() for span in line["spans"] if span["text"].strip()}
             assert not ({"horizontal body text", "vertical label"} <= texts), \
                 "perpendicular text merged into one line"
+
+
+def test_link_spans_whole_anchor(tmp_path):
+    import fitz
+
+    url = "https://example.com/anchor"
+    doc = fitz.open()
+    page = doc.new_page(width=400, height=140)
+    size, baseline, left = 18, 60, 40
+    first, second = "Claude ", "Sonnet"
+    first_width = fitz.get_text_length(first, fontname="helv", fontsize=size)
+    second_width = fitz.get_text_length(second, fontname="hebo", fontsize=size)
+    # One link annotation over two runs that pdftext splits into separate spans
+    page.insert_text((left, baseline), first, fontname="helv", fontsize=size)
+    page.insert_text((left + first_width, baseline), second, fontname="hebo", fontsize=size)
+    page.insert_link({
+        "kind": fitz.LINK_URI,
+        "uri": url,
+        "from": fitz.Rect(left, baseline - size, left + first_width + second_width, baseline + 4),
+    })
+    # An unlinked line right below, so a link bleeding into its neighbour is caught
+    page.insert_text((left, baseline + 40), "unlinked tail", fontname="helv", fontsize=size)
+    path = tmp_path / "multi_span_link.pdf"
+    doc.save(str(path))
+    doc.close()
+
+    pages: Pages = dictionary_output(str(path))
+    spans = [
+        span
+        for page in pages
+        for block in page["blocks"]
+        for line in block["lines"]
+        for span in line["spans"]
+    ]
+    linked = "".join(span["text"] for span in spans if span["url"] == url)
+    assert linked.strip() == "Claude Sonnet"
+    assert all(not span["url"] for span in spans if "unlinked" in span["text"])


### PR DESCRIPTION
Fixes #42.

## Problem

`merge_links` maps each link annotation onto exactly one span:

```python
max_intersection = intersection_link.argmax()
...
span_link_map.setdefault(max_intersection, [])
span_link_map[max_intersection].append(link)
```

A linked phrase is rarely a single span, though — spans get split whenever the font
changes and at the zero-width spacers pdfium emits between words. So for a link over
"Claude 3.7 Sonnet", only the span with the largest overlap keeps the url and every
other word of the same anchor comes back with `"url": ""`, which is what #42 reports.

## Fix

Attach the link to every span it *substantially* covers, normalizing the overlap by
`min(span_area, link_area)`. That keeps both directions:

- a short span lying entirely inside the link (`Sonnet`) → ratio 1.0, matched;
- a long span that swallows the whole link (only one word of a sentence is linked)
  → ratio 1.0, matched, and `_reconstruct_spans` then splits it char by char, exactly
  as before;
- the sliver of the neighbouring line a link rect often reaches into → small ratio,
  ignored, so links don't bleed across lines.

The span with the largest overlap is always kept, so nothing that resolves today
stops resolving. `_reconstruct_spans` is unchanged and still decides per character,
so a partially covered span is split rather than tagged wholesale.

## Verification

Reproducer — one link annotation over two runs in different fonts:

```python
page.insert_text((left, baseline), "Claude ", fontname="helv", fontsize=18)
page.insert_text((left + w1, baseline), "Sonnet", fontname="hebo", fontsize=18)
page.insert_link({"kind": fitz.LINK_URI, "uri": url,
                  "from": fitz.Rect(left, baseline - 18, left + w1 + w2, baseline + 4)})
```

before:

```text
span 'Claude ' url='https://example.com/anchor'
span 'Sonnet'  url=''
```

after:

```text
span 'Claude ' url='https://example.com/anchor'
span 'Sonnet'  url='https://example.com/anchor'
```

`test_link_spans_whole_anchor` covers this and also asserts the unlinked line right
below stays unlinked. It fails on `master` (`assert 'Claude' == 'Claude Sonnet'`) and
passes with the change. Full suite: 43 passed before, 44 passed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
